### PR TITLE
feat:upgrade androidx test libs to fix android test manifest merger error

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -135,6 +135,11 @@ android {
     composeOptions {
         kotlinCompilerExtensionVersion libs.versions.compose.get()
     }
+
+    packagingOptions {
+        exclude 'META-INF/AL2.0'
+        exclude 'META-INF/LGPL2.1'
+    }
 }
 
 protobuf {
@@ -198,8 +203,10 @@ dependencies {
     }
 
     testImplementation 'junit:junit:4.13.2'
-    androidTestImplementation 'androidx.test.ext:junit:1.1.2'
-    androidTestImplementation 'androidx.test.espresso:espresso-core:3.3.0'
+    androidTestImplementation libs.androidx.test.core
+    androidTestImplementation libs.androidx.test.runner
+    androidTestImplementation libs.androidx.test.ext.junit
+    androidTestImplementation libs.androidx.test.espresso
 }
 
 apply from: 'translate.gradle'

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -203,10 +203,7 @@ dependencies {
     }
 
     testImplementation 'junit:junit:4.13.2'
-    androidTestImplementation libs.androidx.test.core
-    androidTestImplementation libs.androidx.test.runner
-    androidTestImplementation libs.androidx.test.ext.junit
-    androidTestImplementation libs.androidx.test.espresso
+    androidTestImplementation libs.bundles.androidx.test
 }
 
 apply from: 'translate.gradle'

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -19,8 +19,18 @@ protobuf = "3.15.7"
 work = "2.7.0-alpha02"
 dataStore = "1.0.0-alpha08"
 exoplayer = "2.13.3"
+androidx_test_core = "1.4.0-alpha05"
+androidx_test_runner = "1.4.0-alpha05"
+extJUnitVersion = "1.1.3-alpha05"
+espressoVersion = "3.4.0-alpha05"
 
 [libraries]
+# androidx test
+androidx-test-core = {module = "androidx.test:core", version.ref = "androidx_test_core"}
+androidx-test-runner = {module = "androidx.test:runner", version.ref = "androidx_test_runner"}
+androidx-test-ext-junit = {module = "androidx.test.ext:junit", version.ref = "extJUnitVersion"}
+androidx-test-espresso = {module = "androidx.test.espresso:espresso-core", version.ref = "espressoVersion"}
+
 # Compose
 compose-ui-base = { module = "androidx.compose.ui:ui", version.ref = "compose" }
 compose-ui-test = { module = "androidx.compose.ui:ui-test", version.ref = "compose" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -19,15 +19,14 @@ protobuf = "3.15.7"
 work = "2.7.0-alpha02"
 dataStore = "1.0.0-alpha08"
 exoplayer = "2.13.3"
-androidx_test_core = "1.4.0-alpha05"
-androidx_test_runner = "1.4.0-alpha05"
+androidx_test = "1.4.0-alpha05"
 extJUnitVersion = "1.1.3-alpha05"
 espressoVersion = "3.4.0-alpha05"
 
 [libraries]
 # androidx test
-androidx-test-core = {module = "androidx.test:core", version.ref = "androidx_test_core"}
-androidx-test-runner = {module = "androidx.test:runner", version.ref = "androidx_test_runner"}
+androidx-test-core = {module = "androidx.test:core", version.ref = "androidx_test"}
+androidx-test-runner = {module = "androidx.test:runner", version.ref = "androidx_test"}
 androidx-test-ext-junit = {module = "androidx.test.ext:junit", version.ref = "extJUnitVersion"}
 androidx-test-espresso = {module = "androidx.test.espresso:espresso-core", version.ref = "espressoVersion"}
 
@@ -108,6 +107,12 @@ protobuf-javalite = { module = "com.google.protobuf:protobuf-javalite", version.
 exoplayer = { module = "com.google.android.exoplayer:exoplayer", version.ref = "exoplayer" }
 
 [bundles]
+androidx-test = [
+    "androidx-test-core",
+    "androidx-test-runner",
+    "androidx-test-ext-junit",
+    "androidx-test-espresso",
+]
 compose = [
     "compose-ui-base",
     "compose-ui-tooling",


### PR DESCRIPTION
The AndroidManifest.xml additions included in the test libraries need to include explicit values for "android:exported" or apps targeting 'S' (Android 12) cannot properly run lint/tests. see details in :https://github.com/android/android-test/issues/896
So I upgrade the version of androidX test libraries。
packagingOptions block is added according to this issue:https://github.com/Kotlin/kotlinx.coroutines/issues/2023