### PR TITLE
Use "%20" instead of raw space in Mastodon OAuth URL

### DIFF
--- a/services/src/main/java/com/twidere/services/mastodon/MastodonOAuthService.kt
+++ b/services/src/main/java/com/twidere/services/mastodon/MastodonOAuthService.kt
@@ -58,7 +58,7 @@ class MastodonOAuthService(
     fun getWebOAuthUrl(response: CreateApplicationResponse) =
         "$host/oauth/authorize?client_id=${response.clientID}&response_type=code&redirect_uri=${response.redirectURI}&scope=${
         scopes.joinToString(
-            " "
+            "%20"
         ) { it.name }
         }"
 


### PR DESCRIPTION
Fixes #326