### PR TITLE
fix null status in DbStatusWithMediaAndUser

### DIFF
--- a/common/src/androidMain/kotlin/com/twidere/twiderex/room/db/model/DbStatusReference.kt
+++ b/common/src/androidMain/kotlin/com/twidere/twiderex/room/db/model/DbStatusReference.kt
@@ -62,7 +62,7 @@ internal data class DbStatusReferenceWithStatus(
     entityColumn = "statusKey",
     entity = DbStatusV2::class
   )
-  val status: DbStatusWithMediaAndUser
+  val status: DbStatusWithMediaAndUser?
 )
 
 internal fun DbStatusWithMediaAndUser?.toDbStatusReference(
@@ -98,7 +98,7 @@ internal data class DbStatusWithReference(
 internal suspend fun List<DbStatusWithReference>.saveToDb(
   database: RoomCacheDatabase
 ) {
-  this.map { it.references.map { it.status } + it.status }
+  this.map { it.references.mapNotNull { it.status } + it.status }
     .flatten()
     .saveToDb(database = database)
   this.flatMap { it.references }.map { it.reference }.let {

--- a/common/src/androidMain/kotlin/com/twidere/twiderex/room/db/transform/StatusTransform.kt
+++ b/common/src/androidMain/kotlin/com/twidere/twiderex/room/db/transform/StatusTransform.kt
@@ -137,7 +137,8 @@ internal fun DbStatusWithReference.toUi(
     isGap = isGap,
     url = url.toUi(),
     reaction = reaction,
-    referenceStatus = references.map {
+    referenceStatus = references.mapNotNull {
+      it.status ?: return@mapNotNull null
       it.reference.referenceType to it.status.toUi(
         accountKey = accountKey,
         isGap = isGap,
@@ -296,7 +297,8 @@ internal fun DbPagingTimelineWithStatus.toUi(
     isGap = timeline.isGap,
     url = url.toUi(),
     reaction = reaction,
-    referenceStatus = status.references.map {
+    referenceStatus = status.references.mapNotNull {
+      it.status ?: return@mapNotNull null
       it.reference.referenceType to it.status.toUi(
         accountKey = accountKey
       )


### PR DESCRIPTION
Closes: #313

```
Fatal Exception: java.lang.NullPointerException: Parameter specified as non-null is null: method ve.q.<init>, parameter status
       at com.twidere.twiderex.room.db.model.DbStatusReferenceWithStatus.<init>(DbStatusReferenceWithStatus.java:2)
       at com.twidere.twiderex.room.db.dao.RoomPagingTimelineDao_Impl.__fetchRelationshipstatusReferenceAscomTwidereTwiderexRoomDbModelDbStatusReferenceWithStatus(RoomPagingTimelineDao_Impl.java:14)
       at com.twidere.twiderex.room.db.dao.RoomPagingTimelineDao_Impl.__fetchRelationshipstatusAscomTwidereTwiderexRoomDbModelDbStatusWithReference(RoomPagingTimelineDao_Impl.java:16)
       at com.twidere.twiderex.room.db.dao.RoomPagingTimelineDao_Impl$11.call(RoomPagingTimelineDao_Impl.java:1)
       at androidx.room.CoroutinesRoom$Companion$execute$4$job$1.invokeSuspend(CoroutinesRoom.java:5)
       at kotlin.coroutines.jvm.internal.BaseContinuationImpl.resumeWith(BaseContinuationImpl.java:8)
       at kotlinx.coroutines.DispatchedTask.run(DispatchedTask.java:86)
       at androidx.room.TransactionExecutor.execute$lambda-1$lambda-0(TransactionExecutor.java:20)
       at androidx.room.MultiInstanceInvalidationClient$callback$1$$InternalSyntheticLambda$1$e0384cf52252c7e972fa2891534fdd0952f950b0b4857bcff2122a48cca953dc$0.run$bridge(MultiInstanceInvalidationClient.java:20)
       at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1167)
       at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:641)
       at java.lang.Thread.run(Thread.java:923)
```